### PR TITLE
DG-12631 improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .gradle
 build
+
+# Jetbrains/IntelliJ project files
+.idea
+*.iml

--- a/src/main/groovy/com/mhackner/cloudflare/AsyncCloudFlareClient.groovy
+++ b/src/main/groovy/com/mhackner/cloudflare/AsyncCloudFlareClient.groovy
@@ -14,7 +14,7 @@ class AsyncCloudFlareClient {
     private final AsyncHTTPBuilder http
 
     AsyncCloudFlareClient(String apiKey, String email, String url = 'https://api.cloudflare.com/client/v4/') {
-        http = new AsyncHTTPBuilder(uri: url, contentType: ContentType.JSON)
+        http = new AsyncCloudFlareHTTPBuilder(uri: url, contentType: ContentType.JSON)
         http.headers = ['X-Auth-Key': apiKey, 'X-Auth-Email': email, 'User-Agent': 'HackAttack AsyncCloudFlareClient']
     }
 

--- a/src/main/groovy/com/mhackner/cloudflare/AsyncCloudFlareClientException.groovy
+++ b/src/main/groovy/com/mhackner/cloudflare/AsyncCloudFlareClientException.groovy
@@ -1,0 +1,28 @@
+package com.mhackner.cloudflare
+
+import groovyx.net.http.HttpResponseDecorator
+
+public class AsyncCloudFlareClientException extends RuntimeException {
+
+	private HttpResponseDecorator resp
+	private String entityContent
+
+	AsyncCloudFlareClientException(HttpResponseDecorator resp, String entityContent) {
+		this.resp = resp
+		this.entityContent = entityContent
+	}
+
+	public HttpResponseDecorator getResp() {
+		return resp
+	}
+
+	public String getEntityContent() {
+		return entityContent
+	}
+
+
+	@Override
+	public String toString() {
+		return 'AsyncCloudFlareClientException{status=' + resp.getStatusLine() + '}'
+	}
+}

--- a/src/main/groovy/com/mhackner/cloudflare/AsyncCloudFlareHTTPBuilder.groovy
+++ b/src/main/groovy/com/mhackner/cloudflare/AsyncCloudFlareHTTPBuilder.groovy
@@ -1,0 +1,32 @@
+package com.mhackner.cloudflare
+
+import org.apache.http.util.EntityUtils
+
+import groovyx.net.http.AsyncHTTPBuilder
+import groovyx.net.http.HttpResponseDecorator
+
+class AsyncCloudFlareHTTPBuilder extends AsyncHTTPBuilder {
+	AsyncCloudFlareHTTPBuilder(Map<String, ?> args) throws URISyntaxException {
+		super(args)
+	}
+
+	/**
+	 * This failure handler enables client code to access the response body.
+	 * It isn't needed for the {@link CloudFlareClient} because that uses the groovy RESTClient which
+	 * has the feature built in.
+	 *
+	 * @param resp response
+	 * @throws AsyncCloudFlareClientException with the response and entity content
+	 */
+	@Override
+	protected void defaultFailureHandler(HttpResponseDecorator resp) {
+		try {
+			String entityContent = EntityUtils.toString(resp.getEntity())
+			throw new AsyncCloudFlareClientException(resp, entityContent)
+		} catch (IOException e) {
+			throw new IllegalStateException("Unable to extract response entity", e)
+		}
+	}
+
+
+}


### PR DESCRIPTION
I found that this code in in `http-builder-0.7.2-sources.jar!/groovyx/net/http/HTTPBuilder.java`:

	finally {
		HttpEntity entity = resp.getEntity();
		if ( entity != null ) entity.consumeContent();
	}

prevents accessing the content of the response using code such as 

	// HttpResponseException ex;
	String body = EntityUtils.toString(ex.getResponse().getEntity(), Charsets.UTF_8);

It fails with a `java.io.IOException: Attempted read from closed stream` error.

It seems like the solution is to use a different response handler that doesn't throw an `groovyx.net.http.HttpResponseException`, but rather throws an exception that includes the body content as a string. After making these changes I was successfully able to get the full HTTP response body from an exception thrown by the async client in my own app.